### PR TITLE
honor `make O=somedir` and `make -jN` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,9 @@ all: modules
 	$(MAKE) --no-print-directory -C "$(O)" mission-all
 
 modules:
-	mkdir -p build/Modules
-	cd build/Modules && cmake ../../Modules && make all -j8 
+	mkdir -p "$(O)/Modules"
+	cd "$(O)/Modules" && cmake "$(CURDIR)/Modules"
+	+make -C "$(O)/Modules" all
 
 install:
 	$(MAKE) --no-print-directory -C "$(O)" mission-install


### PR DESCRIPTION
Fix two issues with the "modules" target:

1. it had destination dir hardcoded, instead of using the $(O) variable

2. option "-j8" was passed to the child make, overriding MAKEFLAGS from
    the command-line or environment