### PR TITLE
[docs] fill-in site description placeholder

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,9 +15,11 @@
 # in the templates via {{ site.myvariable }}.
 title: ICAROUS 
 description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  ICAROUS stands for Independent Configurable Architecture for Reliable
+  Operations of Unmanned Systems. It is a software architecture that enables
+  the robust integration of mission specific software modules and highly
+  assured core algorithms for building safety-centric autonomous unmanned
+  aircraft applications.
 baseurl: "/icarous" # the subpath of your site, e.g. /blog
 url: "https://nasa.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 


### PR DESCRIPTION
I simply copied the first two sentences from `index.md` introduction.