### PR TITLE
Fix Issue #91, Correct typo in dds_interface.c code

### DIFF
--- a/apps/dds_interface/fsw/src/dds_interface.c
+++ b/apps/dds_interface/fsw/src/dds_interface.c
@@ -118,8 +118,8 @@ void DDS_INTERFACE_ProcessPacket(){
                          0,
                          traffic->latitude,
                          traffic->longitude,
-                         traffic->altiude,
-                         traffic->altiude,
+                         traffic->altitude,
+                         traffic->altitude,
                          traffic->vx,
                          traffic->vy,
                          traffic->vz);


### PR DESCRIPTION
Corrected typo in `object_t` members.